### PR TITLE
Fixed typo on groups.yaml

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -445,7 +445,7 @@
     - sensor.dark_sky_precip_intensity
     - sensor.dark_sky_humidity
     - sensor.dark_sky_dew_point
-    - sensor.dark_sky_cloud_ciover
+    - sensor.dark_sky_cloud_cover
     - sensor.dark_sky_nearest_storm_distance
     - sensor.dark_sky_wind_speed
     - sensor.dark_sky_wind_bearing


### PR DESCRIPTION
Hi. 

Typo fix on groups.yaml:

```sensor.dark_sky_cloud_ciover``` -> sensor.dark_sky_cloud_cover.

Fixes #1.

Thank you.